### PR TITLE
Migrate mock data to production

### DIFF
--- a/src/spec_bot_mvp/config/settings.py
+++ b/src/spec_bot_mvp/config/settings.py
@@ -9,7 +9,6 @@ import os
 import configparser
 from typing import Optional
 from pathlib import Path
-import streamlit as st
 from dotenv import load_dotenv
 
 class Settings:
@@ -61,13 +60,45 @@ class Settings:
     def confluence_space(self) -> str:
         return self._config.get('atlassian', 'confluence_space', fallback='CLIENTTOMO')
     
+    # step3_cql_search.py で期待される設定プロパティ
     @property
-    def jira_url(self) -> str:
+    def jira_base_url(self) -> str:
+        """Jira ベースURL"""
         return f"https://{self.atlassian_domain}"
     
     @property
-    def confluence_url(self) -> str:
+    def jira_username(self) -> str:
+        """Jira ユーザー名（通常はメールアドレス）"""
+        return self.atlassian_email
+    
+    @property
+    def jira_token(self) -> str:
+        """Jira API トークン"""
+        return self.atlassian_api_token
+    
+    @property
+    def confluence_base_url(self) -> str:
+        """Confluence ベースURL"""
         return f"https://{self.atlassian_domain}"
+    
+    @property
+    def confluence_username(self) -> str:
+        """Confluence ユーザー名（通常はメールアドレス）"""
+        return self.atlassian_email
+    
+    @property
+    def confluence_token(self) -> str:
+        """Confluence API トークン"""
+        return self.atlassian_api_token
+    
+    # 互換性のための古いプロパティ（後方互換性保持）
+    @property
+    def jira_url(self) -> str:
+        return self.jira_base_url
+    
+    @property
+    def confluence_url(self) -> str:
+        return self.confluence_base_url
     
     # Gemini設定
     @property


### PR DESCRIPTION
Migrate CQL search in `spec_bot_mvp` from mock data to real Atlassian API integration to use production data.

This PR updates the `spec_bot_mvp` to connect to the actual Atlassian API (Jira and Confluence) for CQL search operations, incorporating the 3-stage search strategy and result standardization previously developed for `spec_bot`. It includes a fallback to mock data if API settings are incomplete.

---

[Open in Web](https://cursor.com/agents?id=bc-87d00ddf-2f77-4f07-863f-e7bac7d76240) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-87d00ddf-2f77-4f07-863f-e7bac7d76240) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)