### PR TITLE
Fix session state modification error

### DIFF
--- a/src/spec_bot_mvp/ui/streamlit_app_integrated.py
+++ b/src/spec_bot_mvp/ui/streamlit_app_integrated.py
@@ -81,6 +81,35 @@ def render_sidebar():
     with st.sidebar:
         st.markdown("## 📊 検索対象データソース")
         
+        # 🗑️ コンテンツフィルター（新規追加）
+        st.markdown("### 🗑️ コンテンツフィルター")
+        
+        # 削除ページを含むチェックボックス（session_stateへの手動設定を削除）
+        include_deleted = st.checkbox(
+            "削除ページを含む",
+            value=False,
+            help="【削除】【廃止】などのマークが付いたページも検索結果に含める",
+            key="include_deleted_pages"
+        )
+        
+        # 除外フィルター状況の可視化
+        if include_deleted:
+            st.success("🟢 除外フィルター: 無効（すべてのページを表示）")
+        else:
+            st.info("🔴 除外フィルター: 有効（削除・廃止ページを除外）")
+            with st.expander("🔍 除外対象パターン", expanded=False):
+                st.caption("以下のパターンを含むタイトルを除外:")
+                st.markdown("""
+                - 【削除】【削除予定】【削除済み】
+                - 【廃止】【廃止予定】【システム廃止】  
+                - 【終了】【停止】【無効】【利用停止】
+                - 【非推奨】【deprecated】【obsolete】
+                - 【テスト用】【一時的】【暫定】
+                - %%削除%% %%廃止%% などの%記号
+                """)
+        
+        st.divider()
+        
         # フィルターオプション初期化
         if 'filter_options' not in st.session_state:
             st.session_state.filter_options = {


### PR DESCRIPTION
Add 'Include deleted pages' filter UI to sidebar and fix Streamlit session state modification error.

The `StreamlitAPIException` occurred because `st.session_state.include_deleted_pages` was being manually assigned after the `st.checkbox` widget, which already manages this state via its `key`, was instantiated. The fix removes the redundant manual assignment.

---

[Open in Web](https://cursor.com/agents?id=bc-cf16ae28-38a0-49f2-bc08-3f0d96f4944f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cf16ae28-38a0-49f2-bc08-3f0d96f4944f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)